### PR TITLE
Fixed error in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ void* NvnBootstrapHook(const char* name) {
 int main() {
     // In your main function, initialize the library and register callbacks
     // (Make sure this is called before the nvnBootstrap hook)
-    imgui_xeno_init(&ImGuiRenderCallback, &ImGuiInitCallback);
+    imgui_xeno_init(&ImGuiInitCallback, &ImGuiRenderCallback);
     return 0;
 }
 ```


### PR DESCRIPTION
Parameters in the `imgui_xeno_init` function call example are in the wrong order, fixed that